### PR TITLE
changes made in the first three steps of the wf

### DIFF
--- a/Milad_wf.wdl
+++ b/Milad_wf.wdl
@@ -1,0 +1,35 @@
+version 1.0
+
+import "tasks/concat_fastqs_0.wdl" as concat_fastqsTask
+import "tasks/fastqc_1.wdl" as fastqcTask
+import "tasks/multiqc_2.wdl" as multiqctask
+
+workflow main {
+    input {
+        String fastq_dir
+    }
+
+    call concat_fastqsTask.concat_fastqs_task {
+        input:
+            fastq_dir = fastq_dir
+    }
+
+    scatter (f in concat_fastqs_task.fastq_array) {
+        call fastqcTask.fastqc_task {
+            input:
+                 fastq_file = f
+        }
+    }
+
+    call multiqctask.multiqc_task {
+        input:
+            fastqc_outputs= flatten(fastqc_task.fastqc_output)
+    }
+
+    output {
+        Array[File] fastq_output = concat_fastqs_task.fastq_array
+        Array[File] fastqc_output = flatten(fastqc_task.fastqc_output)
+        File multiqc_report = multiqc_task.multiqc_report
+        File multiqc_data = multiqc_task.multiqc_data
+    }
+}

--- a/tasks/concat_fastqs_0.wdl
+++ b/tasks/concat_fastqs_0.wdl
@@ -1,0 +1,17 @@
+version 1.0
+
+task concat_fastqs_task {
+    
+    input {
+        String fastq_dir
+    }
+
+    command <<<
+        mkdir temp_fastq_dir # temporary dir that is in cromwell sub_dir
+        cp ~{fastq_dir}/* temp_fastq_dir 
+    >>>
+
+    output {
+        Array[File] fastq_array = glob("~{fastq_dir}/*")
+    }
+}

--- a/tasks/fastqc_1.wdl
+++ b/tasks/fastqc_1.wdl
@@ -1,0 +1,22 @@
+version 1.0
+
+task fastqc_task {
+    input {
+        File fastq_file
+    }
+
+    command <<<
+        # check if dir_fastqc already exists by setting a conditional?
+        mkdir dir_fastqc
+        fastqc -o dir_fastqc --noextract ~{fastq_file}
+    >>>
+
+    output {
+        Array[File] fastqc_output = glob("dir_fastqc/*.{zip,html}")
+    }
+
+    runtime {
+        docker: "staphb/fastqc:0.12.1"
+    }
+} 
+  

--- a/tasks/multiqc_2.wdl
+++ b/tasks/multiqc_2.wdl
@@ -1,0 +1,21 @@
+version 1.0
+
+task multiqc_task {
+    input {
+        Array[File] fastqc_outputs
+    }
+
+    command <<<
+        mkdir dir_multiqc
+        multiqc ~{sep= ' ' fastqc_outputs} -o dir_multiqc
+    >>>
+
+    output {
+        File multiqc_report = "dir_multiqc/multiqc_report.html"
+        File multiqc_data = "dir_multiqc/multiqc_data"
+    }
+
+    runtime {
+        docker: "multiqc/multiqc:latest"
+    }
+}


### PR DESCRIPTION
you may need to delete the "main.output_dir": "/mnt/data1/working_directory/ray/SBGS1/outputs" from inputs.json file. The output files will be stored into the Cromwell-outputs dir. 

I will check the permission restriction error that I got when running the workflow on NHS server. 

It might be a good idea for you to run the Milad_wf on the server first, since you may have the necessary permissions that I don’t. If it results in the same permission restriction error in the logs, I will investigate the issue further.”

Next tasks that I will do: 

- preprocessing steps such as trimming the reads,...
- Generating the post-processing multiqc report 